### PR TITLE
Grouped rows table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "8.7.0",
+      "version": "8.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "8.7.2",
+  "version": "8.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "8.7.2",
+      "version": "8.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "8.7.6",
+  "version": "8.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "8.7.6",
+      "version": "8.7.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "8.7.1",
+  "version": "8.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "8.7.1",
+      "version": "8.7.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "8.7.4",
+  "version": "8.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "8.7.4",
+      "version": "8.7.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "8.7.3",
+  "version": "8.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "8.7.3",
+      "version": "8.7.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "8.6.8",
+  "version": "8.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "8.6.8",
+      "version": "8.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "8.7.5",
+  "version": "8.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "8.7.5",
+      "version": "8.7.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "8.6.7",
+  "version": "8.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "8.6.7",
+      "version": "8.6.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "8.6.7",
+  "version": "8.6.8",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-by-toyota/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "8.7.2",
+  "version": "8.7.3",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-by-toyota/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "8.7.5",
+  "version": "8.7.6",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-by-toyota/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-by-toyota/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "8.7.3",
+  "version": "8.7.4",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-by-toyota/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "8.6.8",
+  "version": "8.7.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-by-toyota/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "8.7.1",
+  "version": "8.7.2",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-by-toyota/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "8.7.4",
+  "version": "8.7.5",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-by-toyota/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "8.7.6",
+  "version": "8.7.7",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-by-toyota/lakefront",

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -319,9 +319,19 @@ const Table: React.FC<TableProps> = ({
   }, [stickyHeaders, infiniteScroll]);
 
   const memoizedColumns = useMemo(() => {
+    let processedColumns = [...columns];
+
+    // Disable sorting on non-grouped columns when grouped rows is enabled
+    if (groupedRows?.enabled && groupedRows.groupBy) {
+      processedColumns = processedColumns.map(column => ({
+        ...column,
+        enableSorting: column.id === groupedRows.groupBy || (column as any).accessorKey === groupedRows.groupBy
+      }));
+    }
+
     if (moreActionsConfig) {
       return [
-        ...columns,
+        ...processedColumns,
         {
           id: 'more-actions',
           header: '',
@@ -341,8 +351,8 @@ const Table: React.FC<TableProps> = ({
         } as ColumnDef<any, any>
       ];
     }
-    return columns;
-  }, [columns, moreActionsConfig]);
+    return processedColumns;
+  }, [columns, moreActionsConfig, groupedRows]);
 
 
   // Use the state and functions returned from useReactTable to build your UI

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -89,6 +89,11 @@ export interface GroupedRowsConfig {
    * For example: 'platform' will merge platform column cells.
    */
   groupBy: string;
+  /**
+   * Enable alternating background colors for grouped rows.
+   * When true, alternates between primary and secondary background colors for each group.
+   */
+  alternatingColors?: boolean;
 }
 
 export interface TableSettingsConfig {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -79,6 +79,18 @@ export interface InfiniteScrollConfig {
   stickyHeaders?: boolean;
 }
 
+export interface GroupedRowsConfig {
+  /**
+   * Enable grouped rows functionality with Excel-style merged cells.
+   */
+  enabled: boolean;
+  /**
+   * Column ID to group by for Excel-style merged cells.
+   * For example: 'platform' will merge platform column cells.
+   */
+  groupBy: string;
+}
+
 export interface TableSettingsConfig {
   /**
    * Enable the display of the settings panel.
@@ -226,6 +238,11 @@ export interface TableProps<T = any> {
    * Additional props for the table wrapper when tableSettings is enabled.
    */
   wrapperProps?: ComponentPropsWithoutRef<'div'>;
+  /**
+   * Configuration for grouped rows functionality.
+   * When provided, rows will be grouped by the specified column.
+   */
+  groupedRows?: GroupedRowsConfig;
 }
 
 /**
@@ -252,7 +269,8 @@ const Table: React.FC<TableProps> = ({
   infiniteScroll,
   stickyHeaders,
   tableSettings,
-  wrapperProps
+  wrapperProps,
+  groupedRows
 }) => {
   /** initialSortBy must be memoized */
   const initialSortByData: SortingState = useMemo(
@@ -326,6 +344,7 @@ const Table: React.FC<TableProps> = ({
     return columns;
   }, [columns, moreActionsConfig]);
 
+
   // Use the state and functions returned from useReactTable to build your UI
   const enableMultiSort = options.enableMultiSort ?? true;
   const table = useReactTable({
@@ -346,7 +365,7 @@ const Table: React.FC<TableProps> = ({
     getExpandedRowModel: getExpandedRowModel(),
     enableExpanding: true,
     getRowCanExpand: () => true,
-    autoResetExpanded: true,
+    autoResetExpanded: false,
     enableMultiSort,
     columnResizeMode: 'onChange',
     ...options
@@ -357,6 +376,7 @@ const Table: React.FC<TableProps> = ({
       onChangeSort(sorting[0], sorting);
     }
   }, [sorting, onChangeSort]);
+
 
   // Ref for the loading indicator at the bottom of the table
   const loadMoreRef = useRef<HTMLTableRowElement>(null);
@@ -497,6 +517,7 @@ const Table: React.FC<TableProps> = ({
             contextMenuConfig={contextMenuConfig}
             moreActionsConfig={moreActionsConfig}
             onRenderError={() => setHasRenderError(true)}
+            groupedRows={groupedRows}
           />
         );
       })}

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -365,7 +365,7 @@ const Table: React.FC<TableProps> = ({
     getExpandedRowModel: getExpandedRowModel(),
     enableExpanding: true,
     getRowCanExpand: () => true,
-    autoResetExpanded: false,
+    autoResetExpanded: true,
     enableMultiSort,
     columnResizeMode: 'onChange',
     ...options

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -2,7 +2,7 @@ import { FC, Fragment, ReactNode, useState } from 'react';
 import { flexRender } from '@tanstack/react-table';
 import ContextMenu from '../ContextMenu';
 import { RowHoverContext } from './RowHoverContext';
-import { ContextMenuConfig, MoreActionsConfig } from './Table';
+import { ContextMenuConfig, GroupedRowsConfig, MoreActionsConfig } from './Table';
 import CellErrorBoundary from './CellErrorBoundary';
 
 export interface TableRowProps {
@@ -12,9 +12,10 @@ export interface TableRowProps {
     contextMenuConfig?: ContextMenuConfig;
     moreActionsConfig?: MoreActionsConfig;
     onRenderError?: () => void;
+    groupedRows?: GroupedRowsConfig;
 }
 
-const TableRow: FC<TableRowProps> = ({ row, rowProps, renderRowSubComponent, contextMenuConfig, moreActionsConfig, onRenderError }) => {
+const TableRow: FC<TableRowProps> = ({ row, rowProps, renderRowSubComponent, contextMenuConfig, moreActionsConfig, onRenderError, groupedRows }) => {
     const [isHovered, setIsHovered] = useState(false);
 
     // Get the menu items for this specific row
@@ -33,13 +34,67 @@ const TableRow: FC<TableRowProps> = ({ row, rowProps, renderRowSubComponent, con
         onMouseLeave: () => setIsHovered(false),
     };
 
-    const cells = row.getVisibleCells().map((cell: any) => (
-        <td key={cell.id}>
-            <CellErrorBoundary onError={onRenderError}>
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-            </CellErrorBoundary>
-        </td>
-    ));
+    const cells = row.getVisibleCells().map((cell: any, cellIndex: number) => {
+        // Check if this is a grouped column and if we should render it with merged cells
+        if (groupedRows?.enabled && cell.column.id === groupedRows.groupBy) {
+            // Check if this is the first row with this group value
+            const currentValue = cell.getValue();
+            const rowIndex = parseInt(row.id);
+
+            // Find all consecutive rows with the same group value
+            let spanCount = 1;
+            const allRows = cell.getContext().table.getRowModel().rows;
+
+            // Count how many consecutive rows have the same value
+            for (let i = rowIndex + 1; i < allRows.length; i++) {
+                const nextRow = allRows[i];
+                const nextCell = nextRow.getVisibleCells().find((c: any) => c.column.id === groupedRows.groupBy);
+                if (nextCell && nextCell.getValue() === currentValue) {
+                    spanCount++;
+                } else {
+                    break;
+                }
+            }
+
+            // Check if this is the first occurrence of this group value
+            let isFirstOccurrence = true;
+            if (rowIndex > 0) {
+                const prevRow = allRows[rowIndex - 1];
+                const prevCell = prevRow.getVisibleCells().find((c: any) => c.column.id === groupedRows.groupBy);
+                if (prevCell && prevCell.getValue() === currentValue) {
+                    isFirstOccurrence = false;
+                }
+            }
+
+            if (isFirstOccurrence) {
+                // This is the first row with this group value - show with rowspan
+                return (
+                    <td key={cell.id} rowSpan={spanCount} style={{
+                        backgroundColor: '#f8f9fa',
+                        borderRight: '1px solid #dee2e6',
+                        verticalAlign: 'top',
+                        fontWeight: '600'
+                    }}>
+                        <CellErrorBoundary onError={onRenderError}>
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </CellErrorBoundary>
+                    </td>
+                );
+            } else {
+                // This is not the first occurrence - skip rendering this cell
+                return null;
+            }
+        } else {
+            // Regular cell
+            return (
+                <td key={cell.id}>
+                    <CellErrorBoundary onError={onRenderError}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </CellErrorBoundary>
+                </td>
+            );
+        }
+    }).filter(cell => cell !== null);
 
     return (
         <RowHoverContext.Provider value={isHovered}>

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -4,7 +4,7 @@ import ContextMenu from '../ContextMenu';
 import { RowHoverContext } from './RowHoverContext';
 import { ContextMenuConfig, GroupedRowsConfig, MoreActionsConfig } from './Table';
 import CellErrorBoundary from './CellErrorBoundary';
-import { GroupedCell } from './tableStyles';
+import { GroupedCell, GroupedRowCell } from './tableStyles';
 
 export interface TableRowProps {
     row: any;
@@ -36,6 +36,47 @@ const TableRow: FC<TableRowProps> = ({ row, rowProps, renderRowSubComponent, con
     };
 
     const cells = row.getVisibleCells().map((cell: Cell<unknown, unknown>): ReactElement | null => {
+        // Helper function to get group information for styling (moved inside cell mapping)
+        const getGroupInfo = () => {
+            if (!groupedRows?.enabled) return null;
+
+            const allRows = cell.getContext().table.getRowModel().rows;
+            const rowIndex = allRows.findIndex((r: any) => r.id === row.id);
+            if (rowIndex === -1) return null;
+
+            const groupByColumn = groupedRows.groupBy;
+            const currentValue = allRows[rowIndex].getVisibleCells()
+                .find((c: any) => c.column.id === groupByColumn)?.getValue();
+
+            // Find which group index this is (for alternating colors)
+            const uniqueGroups: any[] = [];
+            let groupIndex = -1;
+
+            for (let i = 0; i <= rowIndex; i++) {
+                const cellValue = allRows[i].getVisibleCells()
+                    .find((c: any) => c.column.id === groupByColumn)?.getValue();
+
+                if (!uniqueGroups.includes(cellValue)) {
+                    uniqueGroups.push(cellValue);
+                }
+
+                if (cellValue === currentValue && groupIndex === -1) {
+                    groupIndex = uniqueGroups.indexOf(cellValue);
+                }
+            }
+
+            // Check if this is the last row in the group
+            let isLastInGroup = true;
+            if (rowIndex < allRows.length - 1) {
+                const nextRowValue = allRows[rowIndex + 1].getVisibleCells()
+                    .find((c: any) => c.column.id === groupByColumn)?.getValue();
+                isLastInGroup = nextRowValue !== currentValue;
+            }
+
+            return { groupIndex, isLastInGroup };
+        };
+
+        const groupInfo = getGroupInfo();
         // Check if this is a grouped column and if we should render it with merged cells
         if (groupedRows?.enabled && cell.column.id === groupedRows.groupBy) {
             const currentValue = cell.getValue();
@@ -88,23 +129,43 @@ const TableRow: FC<TableRowProps> = ({ row, rowProps, renderRowSubComponent, con
                 }
             }
 
+            // Check if this is the last group in the table for the grouped cell
+            // If rowIndex + spanCount reaches or exceeds the total rows, this is the last group
+            let isGroupedCellLastInGroup = rowIndex + spanCount >= allRows.length;
+
             // This is the first occurrence - render with rowspan
             return (
-                <GroupedCell key={cell.id} rowSpan={spanCount}>
+                <GroupedCell key={cell.id} rowSpan={spanCount} isLastInGroup={isGroupedCellLastInGroup}>
                     <CellErrorBoundary onError={onRenderError}>
                         {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </CellErrorBoundary>
                 </GroupedCell>
             );
         } else {
-            // Regular cell
-            return (
-                <td key={cell.id}>
-                    <CellErrorBoundary onError={onRenderError}>
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </CellErrorBoundary>
-                </td>
-            );
+            // Regular cell - apply group styling if grouping is enabled
+            if (groupedRows?.enabled && groupInfo) {
+                return (
+                    <GroupedRowCell
+                        key={cell.id}
+                        groupIndex={groupInfo.groupIndex}
+                        isLastInGroup={groupInfo.isLastInGroup}
+                        alternatingColors={groupedRows.alternatingColors}
+                    >
+                        <CellErrorBoundary onError={onRenderError}>
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </CellErrorBoundary>
+                    </GroupedRowCell>
+                );
+            } else {
+                // Normal cell when grouping is disabled
+                return (
+                    <td key={cell.id}>
+                        <CellErrorBoundary onError={onRenderError}>
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </CellErrorBoundary>
+                    </td>
+                );
+            }
         }
     }).filter((cellElement: ReactElement | null): cellElement is ReactElement => cellElement !== null);
 

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -1,5 +1,5 @@
-import { FC, Fragment, ReactNode, useState } from 'react';
-import { flexRender } from '@tanstack/react-table';
+import React, { FC, Fragment, ReactNode, useState } from 'react';
+import {Cell, flexRender} from '@tanstack/react-table';
 import ContextMenu from '../ContextMenu';
 import { RowHoverContext } from './RowHoverContext';
 import { ContextMenuConfig, GroupedRowsConfig, MoreActionsConfig } from './Table';
@@ -34,67 +34,83 @@ const TableRow: FC<TableRowProps> = ({ row, rowProps, renderRowSubComponent, con
         onMouseLeave: () => setIsHovered(false),
     };
 
-    const cells = row.getVisibleCells().map((cell: any, cellIndex: number) => {
-        // Check if this is a grouped column and if we should render it with merged cells
-        if (groupedRows?.enabled && cell.column.id === groupedRows.groupBy) {
-            // Check if this is the first row with this group value
-            const currentValue = cell.getValue();
-            const rowIndex = parseInt(row.id);
+    // Helper function to find group cell info
+    const getGroupCellInfo = (cell: Cell<unknown, unknown>, rowIndex: number, allRows: any[]) => {
+        const currentValue = cell.getValue();
+        const groupColumnId = groupedRows!.groupBy;
 
-            // Find all consecutive rows with the same group value
-            let spanCount = 1;
-            const allRows = cell.getContext().table.getRowModel().rows;
-
-            // Count how many consecutive rows have the same value
-            for (let i = rowIndex + 1; i < allRows.length; i++) {
-                const nextRow = allRows[i];
-                const nextCell = nextRow.getVisibleCells().find((c: any) => c.column.id === groupedRows.groupBy);
-                if (nextCell && nextCell.getValue() === currentValue) {
-                    spanCount++;
-                } else {
-                    break;
-                }
+        // Check if previous row has same value (determines if we should render)
+        let isFirstOccurrence = true;
+        if (rowIndex > 0 && allRows[rowIndex - 1]) {
+            const prevRowCell = allRows[rowIndex - 1].getVisibleCells?.()
+                ?.find((c: any) => c.column.id === groupColumnId);
+            if (prevRowCell && prevRowCell.getValue() === currentValue) {
+                isFirstOccurrence = false;
             }
+        }
 
-            // Check if this is the first occurrence of this group value
-            let isFirstOccurrence = true;
-            if (rowIndex > 0) {
-                const prevRow = allRows[rowIndex - 1];
-                const prevCell = prevRow.getVisibleCells().find((c: any) => c.column.id === groupedRows.groupBy);
-                if (prevCell && prevCell.getValue() === currentValue) {
-                    isFirstOccurrence = false;
-                }
-            }
+        if (!isFirstOccurrence) {
+            return { shouldRender: false, spanCount: 0 };
+        }
 
-            if (isFirstOccurrence) {
-                // This is the first row with this group value - show with rowspan
-                return (
-                    <td key={cell.id} rowSpan={spanCount} style={{
-                        backgroundColor: '#f8f9fa',
-                        borderRight: '1px solid #dee2e6',
-                        verticalAlign: 'top',
-                        fontWeight: '600'
-                    }}>
-                        <CellErrorBoundary onError={onRenderError}>
-                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </CellErrorBoundary>
-                    </td>
-                );
+        // Count consecutive rows with same value
+        let spanCount = 1;
+        for (let i = rowIndex + 1; i < allRows.length; i++) {
+            const nextRow = allRows[i];
+            if (!nextRow?.getVisibleCells) break;
+
+            const nextRowCell = nextRow.getVisibleCells()
+                .find((c: any) => c.column.id === groupColumnId);
+            if (nextRowCell && nextRowCell.getValue() === currentValue) {
+                spanCount++;
             } else {
-                // This is not the first occurrence - skip rendering this cell
+                break;
+            }
+        }
+
+        return { shouldRender: true, spanCount };
+    };
+
+    const renderCell = (cell: Cell<unknown, unknown>, rowIndex: number, allRows: any[]): React.ReactElement | null => {
+        const isGroupedColumn = groupedRows?.enabled && cell.column.id === groupedRows.groupBy;
+
+        if (isGroupedColumn) {
+            const { shouldRender, spanCount } = getGroupCellInfo(cell, rowIndex, allRows);
+
+            if (!shouldRender) {
                 return null;
             }
-        } else {
-            // Regular cell
+
             return (
-                <td key={cell.id}>
+                <td key={cell.id} rowSpan={spanCount} style={{
+                    backgroundColor: '#f8f9fa',
+                    borderRight: '1px solid #dee2e6',
+                    verticalAlign: 'top',
+                    fontWeight: '600'
+                }}>
                     <CellErrorBoundary onError={onRenderError}>
                         {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </CellErrorBoundary>
                 </td>
             );
         }
-    }).filter(cell => cell !== null);
+
+        // Regular cell
+        return (
+            <td key={cell.id}>
+                <CellErrorBoundary onError={onRenderError}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </CellErrorBoundary>
+            </td>
+        );
+    };
+
+    const allRows = row.getContext?.()?.table.getRowModel().rows || [];
+    const rowIndex = allRows.findIndex((r: any) => r.id === row.id);
+
+    const cells = row.getVisibleCells()
+        .map((cell: Cell<unknown, unknown>) => renderCell(cell, rowIndex, allRows))
+        .filter((cellElement: React.ReactElement | null): cellElement is React.ReactElement => cellElement !== null);
 
     return (
         <RowHoverContext.Provider value={isHovered}>

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -44,6 +44,7 @@ const TableRow: FC<TableRowProps> = ({ row, rowProps, renderRowSubComponent, con
             let rowIndex = allRows.findIndex((r: any) => r.id === row.id);
             if (rowIndex === -1) {
                 // Fallback if findIndex fails - try parseInt
+                // Most table implementations use row ids that include the index (e.g. "0", "1"), so we can attempt to parse the index from the id
                 const fallbackIndex = parseInt(row.id);
                 if (isNaN(fallbackIndex)) {
                     // If we can't determine index, render as regular cell

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -46,34 +46,29 @@ const TableRow: FC<TableRowProps> = ({ row, rowProps, renderRowSubComponent, con
 
             const groupByColumn = groupedRows.groupBy;
             const currentValue = allRows[rowIndex].getVisibleCells()
-                .find((c: any) => c.column.id === groupByColumn)?.getValue();
+              .find((c: any) => c.column.id === groupByColumn)?.getValue();
 
-            // Find which group index this is (for alternating colors)
-            const uniqueGroups: any[] = [];
-            let groupIndex = -1;
-
-            for (let i = 0; i <= rowIndex; i++) {
-                const cellValue = allRows[i].getVisibleCells()
-                    .find((c: any) => c.column.id === groupByColumn)?.getValue();
-
-                if (!uniqueGroups.includes(cellValue)) {
-                    uniqueGroups.push(cellValue);
-                }
-
-                if (cellValue === currentValue && groupIndex === -1) {
-                    groupIndex = uniqueGroups.indexOf(cellValue);
-                }
-            }
-
-            // Check if this is the last row in the group
             let isLastInGroup = true;
             if (rowIndex < allRows.length - 1) {
                 const nextRowValue = allRows[rowIndex + 1].getVisibleCells()
-                    .find((c: any) => c.column.id === groupByColumn)?.getValue();
+                  .find((c: any) => c.column.id === groupByColumn)?.getValue();
                 isLastInGroup = nextRowValue !== currentValue;
             }
 
-            return { groupIndex, isLastInGroup };
+            if (!groupedRows.alternatingColors) {
+                return { isLastInGroup };
+            }
+
+            const uniqueGroups: any[] = [];
+            for (let i = 0; i <= rowIndex; i++) {
+                const cellValue = allRows[i].getVisibleCells()
+                  .find((c: any) => c.column.id === groupByColumn)?.getValue();
+                if (!uniqueGroups.includes(cellValue)) {
+                    uniqueGroups.push(cellValue);
+                }
+            }
+
+            return { groupIndex: uniqueGroups.indexOf(currentValue), isLastInGroup };
         };
 
         const groupInfo = getGroupInfo();
@@ -147,7 +142,7 @@ const TableRow: FC<TableRowProps> = ({ row, rowProps, renderRowSubComponent, con
                 return (
                     <GroupedRowCell
                         key={cell.id}
-                        groupIndex={groupInfo.groupIndex}
+                        groupIndex={groupInfo.groupIndex ?? 0}
                         isLastInGroup={groupInfo.isLastInGroup}
                         alternatingColors={groupedRows.alternatingColors}
                     >

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -4,6 +4,7 @@ import ContextMenu from '../ContextMenu';
 import { RowHoverContext } from './RowHoverContext';
 import { ContextMenuConfig, GroupedRowsConfig, MoreActionsConfig } from './Table';
 import CellErrorBoundary from './CellErrorBoundary';
+import { GroupedCell } from './tableStyles';
 
 export interface TableRowProps {
     row: any;
@@ -89,16 +90,11 @@ const TableRow: FC<TableRowProps> = ({ row, rowProps, renderRowSubComponent, con
 
             // This is the first occurrence - render with rowspan
             return (
-                <td key={cell.id} rowSpan={spanCount} style={{
-                    backgroundColor: '#f8f9fa',
-                    borderRight: '1px solid #dee2e6',
-                    verticalAlign: 'top',
-                    fontWeight: '600'
-                }}>
+                <GroupedCell key={cell.id} rowSpan={spanCount}>
                     <CellErrorBoundary onError={onRenderError}>
                         {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </CellErrorBoundary>
-                </td>
+                </GroupedCell>
             );
         } else {
             // Regular cell

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Fragment, ReactNode, useState } from 'react';
+import React, {FC, Fragment, ReactElement, ReactNode, useState} from 'react';
 import {Cell, flexRender} from '@tanstack/react-table';
 import ContextMenu from '../ContextMenu';
 import { RowHoverContext } from './RowHoverContext';
@@ -34,53 +34,59 @@ const TableRow: FC<TableRowProps> = ({ row, rowProps, renderRowSubComponent, con
         onMouseLeave: () => setIsHovered(false),
     };
 
-    // Helper function to find group cell info
-    const getGroupCellInfo = (cell: Cell<unknown, unknown>, rowIndex: number, allRows: any[]) => {
-        const currentValue = cell.getValue();
-        const groupColumnId = groupedRows!.groupBy;
+    const cells = row.getVisibleCells().map((cell: Cell<unknown, unknown>): ReactElement | null => {
+        // Check if this is a grouped column and if we should render it with merged cells
+        if (groupedRows?.enabled && cell.column.id === groupedRows.groupBy) {
+            const currentValue = cell.getValue();
+            const allRows = cell.getContext().table.getRowModel().rows;
 
-        // Check if previous row has same value (determines if we should render)
-        let isFirstOccurrence = true;
-        if (rowIndex > 0 && allRows[rowIndex - 1]) {
-            const prevRowCell = allRows[rowIndex - 1].getVisibleCells?.()
-                ?.find((c: any) => c.column.id === groupColumnId);
-            if (prevRowCell && prevRowCell.getValue() === currentValue) {
-                isFirstOccurrence = false;
+            // Use the row's index in the table for reliable positioning
+            let rowIndex = allRows.findIndex((r: any) => r.id === row.id);
+            if (rowIndex === -1) {
+                // Fallback if findIndex fails - try parseInt
+                const fallbackIndex = parseInt(row.id);
+                if (isNaN(fallbackIndex)) {
+                    // If we can't determine index, render as regular cell
+                    return (
+                        <td key={cell.id}>
+                            <CellErrorBoundary onError={onRenderError}>
+                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                            </CellErrorBoundary>
+                        </td>
+                    );
+                } else {
+                    rowIndex = fallbackIndex;
+                }
             }
-        }
 
-        if (!isFirstOccurrence) {
-            return { shouldRender: false, spanCount: 0 };
-        }
-
-        // Count consecutive rows with same value
-        let spanCount = 1;
-        for (let i = rowIndex + 1; i < allRows.length; i++) {
-            const nextRow = allRows[i];
-            if (!nextRow?.getVisibleCells) break;
-
-            const nextRowCell = nextRow.getVisibleCells()
-                .find((c: any) => c.column.id === groupColumnId);
-            if (nextRowCell && nextRowCell.getValue() === currentValue) {
-                spanCount++;
-            } else {
-                break;
+            // Check if previous row has same value (determines if we should render)
+            let isFirstOccurrence = true;
+            if (rowIndex > 0) {
+                const prevRow = allRows[rowIndex - 1];
+                const prevCell = prevRow?.getVisibleCells?.()?.find((c: any) => c.column.id === groupedRows.groupBy);
+                if (prevCell && prevCell.getValue() === currentValue) {
+                    isFirstOccurrence = false;
+                }
             }
-        }
 
-        return { shouldRender: true, spanCount };
-    };
-
-    const renderCell = (cell: Cell<unknown, unknown>, rowIndex: number, allRows: any[]): React.ReactElement | null => {
-        const isGroupedColumn = groupedRows?.enabled && cell.column.id === groupedRows.groupBy;
-
-        if (isGroupedColumn) {
-            const { shouldRender, spanCount } = getGroupCellInfo(cell, rowIndex, allRows);
-
-            if (!shouldRender) {
+            if (!isFirstOccurrence) {
+                // This is not the first occurrence - skip rendering this cell
                 return null;
             }
 
+            // Count consecutive rows with same value for rowspan
+            let spanCount = 1;
+            for (let i = rowIndex + 1; i < allRows.length; i++) {
+                const nextRow = allRows[i];
+                const nextCell = nextRow?.getVisibleCells?.()?.find((c: any) => c.column.id === groupedRows.groupBy);
+                if (nextCell && nextCell.getValue() === currentValue) {
+                    spanCount++;
+                } else {
+                    break;
+                }
+            }
+
+            // This is the first occurrence - render with rowspan
             return (
                 <td key={cell.id} rowSpan={spanCount} style={{
                     backgroundColor: '#f8f9fa',
@@ -93,24 +99,17 @@ const TableRow: FC<TableRowProps> = ({ row, rowProps, renderRowSubComponent, con
                     </CellErrorBoundary>
                 </td>
             );
+        } else {
+            // Regular cell
+            return (
+                <td key={cell.id}>
+                    <CellErrorBoundary onError={onRenderError}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </CellErrorBoundary>
+                </td>
+            );
         }
-
-        // Regular cell
-        return (
-            <td key={cell.id}>
-                <CellErrorBoundary onError={onRenderError}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </CellErrorBoundary>
-            </td>
-        );
-    };
-
-    const allRows = row.getContext?.()?.table.getRowModel().rows || [];
-    const rowIndex = allRows.findIndex((r: any) => r.id === row.id);
-
-    const cells = row.getVisibleCells()
-        .map((cell: Cell<unknown, unknown>) => renderCell(cell, rowIndex, allRows))
-        .filter((cellElement: React.ReactElement | null): cellElement is React.ReactElement => cellElement !== null);
+    }).filter((cellElement: ReactElement | null): cellElement is ReactElement => cellElement !== null);
 
     return (
         <RowHoverContext.Provider value={isHovered}>

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -1,10 +1,10 @@
 import React, {FC, Fragment, ReactElement, ReactNode, useState} from 'react';
-import {Cell, flexRender} from '@tanstack/react-table';
+import {Cell} from '@tanstack/react-table';
 import ContextMenu from '../ContextMenu';
 import { RowHoverContext } from './RowHoverContext';
 import { ContextMenuConfig, GroupedRowsConfig, MoreActionsConfig } from './Table';
-import CellErrorBoundary from './CellErrorBoundary';
 import { GroupedCell, GroupedRowCell } from './tableStyles';
+import {getCellContent, getGroupValue, getRowIndex} from "./tableUtil";
 
 export interface TableRowProps {
     row: any;
@@ -36,132 +36,73 @@ const TableRow: FC<TableRowProps> = ({ row, rowProps, renderRowSubComponent, con
     };
 
     const cells = row.getVisibleCells().map((cell: Cell<unknown, unknown>): ReactElement | null => {
-        // Helper function to get group information for styling (moved inside cell mapping)
-        const getGroupInfo = () => {
-            if (!groupedRows?.enabled) return null;
+        const isGroupingEnabled = groupedRows?.enabled;
+        const isGroupByColumn = cell.column.id === groupedRows?.groupBy;
 
-            const allRows = cell.getContext().table.getRowModel().rows;
-            const rowIndex = allRows.findIndex((r: any) => r.id === row.id);
-            if (rowIndex === -1) return null;
+        const allRows = cell.getContext().table.getRowModel().rows;
+        const rowIndex = getRowIndex(allRows, row.id);
+        const groupByColumn = groupedRows?.groupBy;
+        const currentValue = rowIndex !== -1 && groupByColumn ? getGroupValue(allRows[rowIndex], groupByColumn) : null;
 
-            const groupByColumn = groupedRows.groupBy;
-            const currentValue = allRows[rowIndex].getVisibleCells()
-              .find((c: any) => c.column.id === groupByColumn)?.getValue();
-
-            let isLastInGroup = true;
-            if (rowIndex < allRows.length - 1) {
-                const nextRowValue = allRows[rowIndex + 1].getVisibleCells()
-                  .find((c: any) => c.column.id === groupByColumn)?.getValue();
-                isLastInGroup = nextRowValue !== currentValue;
-            }
-
-            if (!groupedRows.alternatingColors) {
-                return { isLastInGroup };
-            }
-
-            const uniqueGroups: any[] = [];
-            for (let i = 0; i <= rowIndex; i++) {
-                const cellValue = allRows[i].getVisibleCells()
-                  .find((c: any) => c.column.id === groupByColumn)?.getValue();
-                if (!uniqueGroups.includes(cellValue)) {
-                    uniqueGroups.push(cellValue);
-                }
-            }
-
-            return { groupIndex: uniqueGroups.indexOf(currentValue), isLastInGroup };
-        };
-
-        const groupInfo = getGroupInfo();
-        // Check if this is a grouped column and if we should render it with merged cells
-        if (groupedRows?.enabled && cell.column.id === groupedRows.groupBy) {
-            const currentValue = cell.getValue();
-            const allRows = cell.getContext().table.getRowModel().rows;
-
-            // Use the row's index in the table for reliable positioning
-            let rowIndex = allRows.findIndex((r: any) => r.id === row.id);
+        // --- Grouped column cell (with rowspan) ---
+        if (isGroupingEnabled && isGroupByColumn) {
             if (rowIndex === -1) {
-                // Fallback if findIndex fails - try parseInt
-                // Most table implementations use row ids that include the index (e.g. "0", "1"), so we can attempt to parse the index from the id
-                const fallbackIndex = parseInt(row.id);
-                if (isNaN(fallbackIndex)) {
-                    // If we can't determine index, render as regular cell
-                    return (
-                        <td key={cell.id}>
-                            <CellErrorBoundary onError={onRenderError}>
-                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                            </CellErrorBoundary>
-                        </td>
-                    );
-                } else {
-                    rowIndex = fallbackIndex;
-                }
+                return <td key={cell.id}>{getCellContent(cell, onRenderError)}</td>;
             }
 
-            // Check if previous row has same value (determines if we should render)
-            let isFirstOccurrence = true;
-            if (rowIndex > 0) {
-                const prevRow = allRows[rowIndex - 1];
-                const prevCell = prevRow?.getVisibleCells?.()?.find((c: any) => c.column.id === groupedRows.groupBy);
-                if (prevCell && prevCell.getValue() === currentValue) {
-                    isFirstOccurrence = false;
-                }
-            }
+            const prevValue = rowIndex > 0 && groupByColumn ? getGroupValue(allRows[rowIndex - 1], groupByColumn) : null;
+            if (prevValue === currentValue) return null; // not first occurrence, skip
 
-            if (!isFirstOccurrence) {
-                // This is not the first occurrence - skip rendering this cell
-                return null;
-            }
-
-            // Count consecutive rows with same value for rowspan
             let spanCount = 1;
-            for (let i = rowIndex + 1; i < allRows.length; i++) {
-                const nextRow = allRows[i];
-                const nextCell = nextRow?.getVisibleCells?.()?.find((c: any) => c.column.id === groupedRows.groupBy);
-                if (nextCell && nextCell.getValue() === currentValue) {
-                    spanCount++;
-                } else {
-                    break;
-                }
+            while (
+                rowIndex + spanCount < allRows.length &&
+                groupByColumn &&
+                getGroupValue(allRows[rowIndex + spanCount], groupByColumn) === currentValue
+            ) {
+                spanCount++;
             }
 
-            // Check if this is the last group in the table for the grouped cell
-            // If rowIndex + spanCount reaches or exceeds the total rows, this is the last group
-            let isGroupedCellLastInGroup = rowIndex + spanCount >= allRows.length;
-
-            // This is the first occurrence - render with rowspan
             return (
-                <GroupedCell key={cell.id} rowSpan={spanCount} isLastInGroup={isGroupedCellLastInGroup}>
-                    <CellErrorBoundary onError={onRenderError}>
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </CellErrorBoundary>
+                <GroupedCell
+                    key={cell.id}
+                    rowSpan={spanCount}
+                    isLastInGroup={rowIndex + spanCount >= allRows.length}
+                >
+                    {getCellContent(cell, onRenderError)}
                 </GroupedCell>
             );
-        } else {
-            // Regular cell - apply group styling if grouping is enabled
-            if (groupedRows?.enabled && groupInfo) {
-                return (
-                    <GroupedRowCell
-                        key={cell.id}
-                        groupIndex={groupInfo.groupIndex ?? 0}
-                        isLastInGroup={groupInfo.isLastInGroup}
-                        alternatingColors={groupedRows.alternatingColors}
-                    >
-                        <CellErrorBoundary onError={onRenderError}>
-                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </CellErrorBoundary>
-                    </GroupedRowCell>
-                );
-            } else {
-                // Normal cell when grouping is disabled
-                return (
-                    <td key={cell.id}>
-                        <CellErrorBoundary onError={onRenderError}>
-                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </CellErrorBoundary>
-                    </td>
-                );
-            }
         }
+
+        if (isGroupingEnabled && rowIndex !== -1) {
+            const nextValue = rowIndex < allRows.length - 1 && groupByColumn
+                ? getGroupValue(allRows[rowIndex + 1], groupByColumn)
+                : null;
+            const isLastInGroup = nextValue !== currentValue;
+
+            let groupIndex = 0;
+            if (groupedRows.alternatingColors && groupByColumn) {
+                const uniqueGroups: any[] = [];
+                for (let i = 0; i <= rowIndex; i++) {
+                    const val = getGroupValue(allRows[i], groupByColumn);
+                    if (!uniqueGroups.includes(val)) uniqueGroups.push(val);
+                }
+                groupIndex = uniqueGroups.indexOf(currentValue);
+            }
+
+            return (
+                <GroupedRowCell
+                    key={cell.id}
+                    groupIndex={groupIndex}
+                    isLastInGroup={isLastInGroup}
+                    alternatingColors={groupedRows.alternatingColors}
+                >
+                    {getCellContent(cell, onRenderError)}
+                </GroupedRowCell>
+            );
+        }
+
+        return <td key={cell.id}>{getCellContent(cell, onRenderError)}</td>;
+
     }).filter((cellElement: ReactElement | null): cellElement is ReactElement => cellElement !== null);
 
     return (

--- a/src/components/Table/__tests__/Table.groupedRows.test.tsx
+++ b/src/components/Table/__tests__/Table.groupedRows.test.tsx
@@ -2,18 +2,18 @@ import Table from '../Table';
 import { renderWithTheme } from '../../../lib/testing';
 
 const mockData = [
-  { platform: 'TMPOC', region: 'US', total: 7, online: 0, offline: 7 },
-  { platform: 'TMPOC', region: 'JP', total: 3, online: 0, offline: 3 },
-  { platform: 'TMPOC Lite', region: 'US', total: 7, online: 0, offline: 7 },
-  { platform: 'TMPOC Lite', region: 'JP', total: 3, online: 0, offline: 3 },
+  { genre: 'Fiction', title: 'The Great Adventure', author: 'Jane Smith', pages: 324, rating: 4.2 },
+  { genre: 'Fiction', title: 'Mystery of the Lake', author: 'John Doe', pages: 278, rating: 4.5 },
+  { genre: 'Non-Fiction', title: 'History of Technology', author: 'Dr. Brown', pages: 456, rating: 4.1 },
+  { genre: 'Non-Fiction', title: 'Cooking Mastery', author: 'Chef Maria', pages: 312, rating: 4.7 },
 ];
 
 const mockColumns = [
-  { header: 'Platform', accessorKey: 'platform' },
-  { header: 'Region', accessorKey: 'region' },
-  { header: 'Total', accessorKey: 'total' },
-  { header: 'Online', accessorKey: 'online' },
-  { header: 'Offline', accessorKey: 'offline' },
+  { header: 'Genre', accessorKey: 'genre' },
+  { header: 'Title', accessorKey: 'title' },
+  { header: 'Author', accessorKey: 'author' },
+  { header: 'Pages', accessorKey: 'pages' },
+  { header: 'Rating', accessorKey: 'rating' },
 ];
 
 describe('Table with Grouped Rows', () => {
@@ -24,15 +24,15 @@ describe('Table with Grouped Rows', () => {
         columns={mockColumns}
         groupedRows={{
           enabled: true,
-          groupBy: 'platform'
+          groupBy: 'genre'
         }}
       />
     );
 
-    expect(getByText('TMPOC')).toBeInTheDocument();
-    expect(getByText('TMPOC Lite')).toBeInTheDocument();
-    expect(getAllByText('US')).toHaveLength(2);
-    expect(getAllByText('JP')).toHaveLength(2);
+    expect(getByText('Fiction')).toBeInTheDocument();
+    expect(getByText('Non-Fiction')).toBeInTheDocument();
+    expect(getAllByText('The Great Adventure')).toHaveLength(1);
+    expect(getAllByText('History of Technology')).toHaveLength(1);
   });
 
   it('renders normal table when groupedRows is disabled', () => {
@@ -42,13 +42,13 @@ describe('Table with Grouped Rows', () => {
         columns={mockColumns}
         groupedRows={{
           enabled: false,
-          groupBy: 'platform'
+          groupBy: 'genre'
         }}
       />
     );
 
-    const tmpocCells = getAllByText('TMPOC');
-    expect(tmpocCells).toHaveLength(2);
+    const fictionCells = getAllByText('Fiction');
+    expect(fictionCells).toHaveLength(2);
   });
 
   it('renders grouped rows with Excel-style merged cells', () => {
@@ -58,15 +58,15 @@ describe('Table with Grouped Rows', () => {
         columns={mockColumns}
         groupedRows={{
           enabled: true,
-          groupBy: 'platform'
+          groupBy: 'genre'
         }}
       />
     );
 
-    expect(getByText('TMPOC')).toBeInTheDocument();
-    expect(getByText('TMPOC Lite')).toBeInTheDocument();
-    expect(getAllByText('US')).toHaveLength(2);
-    expect(getAllByText('JP')).toHaveLength(2);
+    expect(getByText('Fiction')).toBeInTheDocument();
+    expect(getByText('Non-Fiction')).toBeInTheDocument();
+    expect(getAllByText('Jane Smith')).toHaveLength(1);
+    expect(getAllByText('Dr. Brown')).toHaveLength(1);
   });
 
   it('renders normal table when groupedRows is not provided', () => {
@@ -77,10 +77,10 @@ describe('Table with Grouped Rows', () => {
       />
     );
 
-    const tmpocCells = getAllByText('TMPOC');
-    expect(tmpocCells).toHaveLength(2);
+    const fictionCells = getAllByText('Fiction');
+    expect(fictionCells).toHaveLength(2);
 
-    const tmpocLiteCells = getAllByText('TMPOC Lite');
-    expect(tmpocLiteCells).toHaveLength(2);
+    const nonFictionCells = getAllByText('Non-Fiction');
+    expect(nonFictionCells).toHaveLength(2);
   });
 });

--- a/src/components/Table/__tests__/Table.groupedRows.test.tsx
+++ b/src/components/Table/__tests__/Table.groupedRows.test.tsx
@@ -35,6 +35,40 @@ describe('Table with Grouped Rows', () => {
     expect(getAllByText('History of Technology')).toHaveLength(1);
   });
 
+  it('renders grouped rows with alternating colors when enabled', () => {
+    const {getByText} = renderWithTheme(
+      <Table
+        data={mockData}
+        columns={mockColumns}
+        groupedRows={{
+          enabled: true,
+          groupBy: 'genre',
+          alternatingColors: true
+        }}
+      />
+    );
+
+    expect(getByText('Fiction')).toBeInTheDocument();
+    expect(getByText('Non-Fiction')).toBeInTheDocument();
+  });
+
+  it('renders grouped rows without alternating colors when disabled', () => {
+    const {getByText} = renderWithTheme(
+      <Table
+        data={mockData}
+        columns={mockColumns}
+        groupedRows={{
+          enabled: true,
+          groupBy: 'genre',
+          alternatingColors: false
+        }}
+      />
+    );
+
+    expect(getByText('Fiction')).toBeInTheDocument();
+    expect(getByText('Non-Fiction')).toBeInTheDocument();
+  });
+
   it('renders normal table when groupedRows is disabled', () => {
     const {getAllByText} = renderWithTheme(
       <Table

--- a/src/components/Table/__tests__/Table.groupedRows.test.tsx
+++ b/src/components/Table/__tests__/Table.groupedRows.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
 import Table from '../Table';
 import { renderWithTheme } from '../../../lib/testing';
 
@@ -20,7 +18,7 @@ const mockColumns = [
 
 describe('Table with Grouped Rows', () => {
   it('renders grouped rows when groupedRows is enabled', () => {
-    renderWithTheme(
+    const {getByText, getAllByText} = renderWithTheme(
       <Table
         data={mockData}
         columns={mockColumns}
@@ -31,17 +29,14 @@ describe('Table with Grouped Rows', () => {
       />
     );
 
-    // Check that platform values are shown (should be fewer due to grouping)
-    expect(screen.getByText('TMPOC')).toBeInTheDocument();
-    expect(screen.getByText('TMPOC Lite')).toBeInTheDocument();
-
-    // Check that data rows are still rendered
-    expect(screen.getAllByText('US')).toHaveLength(2);
-    expect(screen.getAllByText('JP')).toHaveLength(2);
+    expect(getByText('TMPOC')).toBeInTheDocument();
+    expect(getByText('TMPOC Lite')).toBeInTheDocument();
+    expect(getAllByText('US')).toHaveLength(2);
+    expect(getAllByText('JP')).toHaveLength(2);
   });
 
   it('renders normal table when groupedRows is disabled', () => {
-    renderWithTheme(
+    const {getAllByText} = renderWithTheme(
       <Table
         data={mockData}
         columns={mockColumns}
@@ -52,13 +47,12 @@ describe('Table with Grouped Rows', () => {
       />
     );
 
-    // Should render platform values as regular cells, not grouped
-    const tmpocCells = screen.getAllByText('TMPOC');
-    expect(tmpocCells).toHaveLength(2); // Two rows with TMPOC platform
+    const tmpocCells = getAllByText('TMPOC');
+    expect(tmpocCells).toHaveLength(2);
   });
 
   it('renders grouped rows with Excel-style merged cells', () => {
-    renderWithTheme(
+    const {getByText, getAllByText} = renderWithTheme(
       <Table
         data={mockData}
         columns={mockColumns}
@@ -69,28 +63,24 @@ describe('Table with Grouped Rows', () => {
       />
     );
 
-    // Check that platform grouping is working with Excel-style merging
-    expect(screen.getByText('TMPOC')).toBeInTheDocument();
-    expect(screen.getByText('TMPOC Lite')).toBeInTheDocument();
-
-    // Regions should still be visible
-    expect(screen.getAllByText('US')).toHaveLength(2);
-    expect(screen.getAllByText('JP')).toHaveLength(2);
+    expect(getByText('TMPOC')).toBeInTheDocument();
+    expect(getByText('TMPOC Lite')).toBeInTheDocument();
+    expect(getAllByText('US')).toHaveLength(2);
+    expect(getAllByText('JP')).toHaveLength(2);
   });
 
   it('renders normal table when groupedRows is not provided', () => {
-    renderWithTheme(
+    const {getAllByText} = renderWithTheme(
       <Table
         data={mockData}
         columns={mockColumns}
       />
     );
 
-    // Should render all platform values as regular cells
-    const tmpocCells = screen.getAllByText('TMPOC');
+    const tmpocCells = getAllByText('TMPOC');
     expect(tmpocCells).toHaveLength(2);
 
-    const tmpocLiteCells = screen.getAllByText('TMPOC Lite');
+    const tmpocLiteCells = getAllByText('TMPOC Lite');
     expect(tmpocLiteCells).toHaveLength(2);
   });
 });

--- a/src/components/Table/__tests__/Table.groupedRows.test.tsx
+++ b/src/components/Table/__tests__/Table.groupedRows.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Table from '../Table';
+import { renderWithTheme } from '../../../lib/testing';
+
+const mockData = [
+  { platform: 'TMPOC', region: 'US', total: 7, online: 0, offline: 7 },
+  { platform: 'TMPOC', region: 'JP', total: 3, online: 0, offline: 3 },
+  { platform: 'TMPOC Lite', region: 'US', total: 7, online: 0, offline: 7 },
+  { platform: 'TMPOC Lite', region: 'JP', total: 3, online: 0, offline: 3 },
+];
+
+const mockColumns = [
+  { header: 'Platform', accessorKey: 'platform' },
+  { header: 'Region', accessorKey: 'region' },
+  { header: 'Total', accessorKey: 'total' },
+  { header: 'Online', accessorKey: 'online' },
+  { header: 'Offline', accessorKey: 'offline' },
+];
+
+describe('Table with Grouped Rows', () => {
+  it('renders grouped rows when groupedRows is enabled', () => {
+    renderWithTheme(
+      <Table
+        data={mockData}
+        columns={mockColumns}
+        groupedRows={{
+          enabled: true,
+          groupBy: 'platform'
+        }}
+      />
+    );
+
+    // Check that platform values are shown (should be fewer due to grouping)
+    expect(screen.getByText('TMPOC')).toBeInTheDocument();
+    expect(screen.getByText('TMPOC Lite')).toBeInTheDocument();
+
+    // Check that data rows are still rendered
+    expect(screen.getAllByText('US')).toHaveLength(2);
+    expect(screen.getAllByText('JP')).toHaveLength(2);
+  });
+
+  it('renders normal table when groupedRows is disabled', () => {
+    renderWithTheme(
+      <Table
+        data={mockData}
+        columns={mockColumns}
+        groupedRows={{
+          enabled: false,
+          groupBy: 'platform'
+        }}
+      />
+    );
+
+    // Should render platform values as regular cells, not grouped
+    const tmpocCells = screen.getAllByText('TMPOC');
+    expect(tmpocCells).toHaveLength(2); // Two rows with TMPOC platform
+  });
+
+  it('renders grouped rows with Excel-style merged cells', () => {
+    renderWithTheme(
+      <Table
+        data={mockData}
+        columns={mockColumns}
+        groupedRows={{
+          enabled: true,
+          groupBy: 'platform'
+        }}
+      />
+    );
+
+    // Check that platform grouping is working with Excel-style merging
+    expect(screen.getByText('TMPOC')).toBeInTheDocument();
+    expect(screen.getByText('TMPOC Lite')).toBeInTheDocument();
+
+    // Regions should still be visible
+    expect(screen.getAllByText('US')).toHaveLength(2);
+    expect(screen.getAllByText('JP')).toHaveLength(2);
+  });
+
+  it('renders normal table when groupedRows is not provided', () => {
+    renderWithTheme(
+      <Table
+        data={mockData}
+        columns={mockColumns}
+      />
+    );
+
+    // Should render all platform values as regular cells
+    const tmpocCells = screen.getAllByText('TMPOC');
+    expect(tmpocCells).toHaveLength(2);
+
+    const tmpocLiteCells = screen.getAllByText('TMPOC Lite');
+    expect(tmpocLiteCells).toHaveLength(2);
+  });
+});

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -1,5 +1,5 @@
 import { ColumnDef } from '@tanstack/react-table';
-import Table, { TableProps, TableSortByOptions, TableSettingsConfig } from './Table';
+import Table, { TableProps, TableSortByOptions, TableSettingsConfig, GroupedRowsConfig } from './Table';
 
-export { TableProps, TableSortByOptions, TableSettingsConfig, ColumnDef as TableColumn };
+export { TableProps, TableSortByOptions, TableSettingsConfig, GroupedRowsConfig, ColumnDef as TableColumn };
 export default Table;

--- a/src/components/Table/tableStyles.ts
+++ b/src/components/Table/tableStyles.ts
@@ -159,7 +159,7 @@ export const GroupedCell = styled.td<{ isLastInGroup?: boolean }>(({ theme, isLa
   }
 }));
 
-export const GroupedRowCell = styled.td<{ groupIndex: number; isLastInGroup?: boolean; alternatingColors?: boolean }>(({ theme, groupIndex, isLastInGroup, alternatingColors }) => ({
+export const GroupedRowCell = styled.td<{ groupIndex: number; isLastInGroup?: boolean; alternatingColors?: boolean }>(({ theme, groupIndex, isLastInGroup, alternatingColors = true}) => ({
   '&&': {
     backgroundColor: alternatingColors && groupIndex % 2 === 1
       ? theme.backgrounds.secondary

--- a/src/components/Table/tableStyles.ts
+++ b/src/components/Table/tableStyles.ts
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { ReactComponent as ArrowUp } from './assets/arrow_drop_up.svg';
 import { ReactComponent as ArrowDown } from './assets/arrow_drop_down.svg';
 import { ReactComponent as Unsorted } from './assets/unsorted.svg';
+import {lightenDarkenColor} from "../../styles/stylesUtil";
 
 export const TableStyle = styled.table(({ theme }) => ({
   padding: 0,
@@ -144,13 +145,27 @@ export const ErrorMessage = styled.td(({ theme }) => ({
   color: theme.foregrounds.error,
 }));
 
-export const GroupedCell = styled.td(({ theme }) => ({
+export const GroupedCell = styled.td<{ isLastInGroup?: boolean }>(({ theme, isLastInGroup }) => ({
   '&&': {
-    backgroundColor: theme.backgrounds.secondary,
-    borderRight: `1px solid ${theme.borderColors.primary}`,
+    backgroundColor: theme.backgrounds.table.groupedRowSecondary,
+    borderRight: `1px solid ${theme.borderColors.secondary}`,
+    borderBottom: !isLastInGroup
+      ? `2px solid ${theme.borderColors.secondary}`
+      : `1px solid ${theme.borderColors.primary}`,
     verticalAlign: 'middle',
     fontWeight: '600',
     color: theme.foregrounds.primary,
     textAlign: 'center'
+  }
+}));
+
+export const GroupedRowCell = styled.td<{ groupIndex: number; isLastInGroup?: boolean; alternatingColors?: boolean }>(({ theme, groupIndex, isLastInGroup, alternatingColors }) => ({
+  '&&': {
+    backgroundColor: alternatingColors && groupIndex % 2 === 1
+      ? theme.backgrounds.secondary
+      : theme.backgrounds.table.groupedRowPrimary,
+    ...(isLastInGroup && {
+      borderBottom: `2px solid ${theme.borderColors.secondary}`,
+    })
   }
 }));

--- a/src/components/Table/tableStyles.ts
+++ b/src/components/Table/tableStyles.ts
@@ -143,3 +143,14 @@ export const HideableTHead = styled.thead<HideableTHeadProps>(({ hide, sticky, t
 export const ErrorMessage = styled.td(({ theme }) => ({
   color: theme.foregrounds.error,
 }));
+
+export const GroupedCell = styled.td(({ theme }) => ({
+  '&&': {
+    backgroundColor: theme.backgrounds.secondary,
+    borderRight: `1px solid ${theme.borderColors.primary}`,
+    verticalAlign: 'middle',
+    fontWeight: '600',
+    color: theme.foregrounds.primary,
+    textAlign: 'center'
+  }
+}));

--- a/src/components/Table/tableUtil.tsx
+++ b/src/components/Table/tableUtil.tsx
@@ -1,4 +1,7 @@
 import { StyledArrowDown, StyledArrowUp, StyledUnsorted } from './tableStyles';
+import {Cell, flexRender} from "@tanstack/react-table";
+import CellErrorBoundary from "./CellErrorBoundary";
+import React from "react";
 
 export interface Column {
     disableSortBy: boolean;
@@ -45,3 +48,21 @@ export const isLastHeader = (
 
     return idx === totalHeaders - 1;
 };
+
+export const getCellContent = (cell: Cell<unknown, unknown>, onRenderError?: () => void) => (
+  <CellErrorBoundary onError={onRenderError}>
+      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+  </CellErrorBoundary>
+);
+
+export const getRowIndex = (allRows: any[], rowId: string): number => {
+    const index = allRows.findIndex((r: any) => r.id === rowId);
+    if (index !== -1) return index;
+    const fallback = parseInt(rowId);
+    return isNaN(fallback) ? -1 : fallback;
+};
+
+export const getGroupValue = (row: any, groupByColumn: string) =>
+  row?.getVisibleCells?.()
+    ?.find((c: any) => c.column.id === groupByColumn)
+    ?.getValue();

--- a/src/stories/Table/Table.stories.tsx
+++ b/src/stories/Table/Table.stories.tsx
@@ -362,11 +362,34 @@ TableWithGroupedRows.args = {
   } as TableProps['tableSettings'],
   groupedRows: {
     enabled: true,
-    groupBy: 'genre'
+    groupBy: 'genre',
+    alternatingColors: true
   } as TableProps['groupedRows'],
   noDataMessage: 'No data found',
   // story props
   storyTitle: 'Table with Grouped Rows (Excel-style merged cells)',
-  storyDescription: 'Genre values are merged in Excel-style with rowspan, showing each genre name only once per group. Each genre (Fiction, Non-Fiction, Science, Biography) shows multiple books underneath with their titles, authors, page counts, and ratings.'
+  storyDescription: 'Genre values are merged in Excel-style with rowspan, showing each genre name only once per group. Each genre (Fiction, Non-Fiction, Science, Biography) shows multiple books underneath with their titles, authors, page counts, and ratings. Alternating colors are enabled to distinguish between different groups, and border separators appear between groups.'
+};
+
+export const TableWithGroupedRowsNoAlternating = GroupedRowsTemplate.bind({});
+TableWithGroupedRowsNoAlternating.args = {
+  columns: GROUPED_ROWS_COLUMNS,
+  data: GROUPED_ROWS_DATA,
+  tableSettings: {
+    columnConfig: {
+      enableColumnHiding: true
+    },
+    enableDownload: true,
+    downloadFilename: 'my-table-export.csv'
+  } as TableProps['tableSettings'],
+  groupedRows: {
+    enabled: true,
+    groupBy: 'genre',
+    alternatingColors: false
+  } as TableProps['groupedRows'],
+  noDataMessage: 'No data found',
+  // story props
+  storyTitle: 'Table with Grouped Rows (No Alternating Colors)',
+  storyDescription: 'Same as above but with alternatingColors set to false, showing grouped rows with consistent background colors and only border separators between groups.'
 };
 

--- a/src/stories/Table/Table.stories.tsx
+++ b/src/stories/Table/Table.stories.tsx
@@ -362,11 +362,11 @@ TableWithGroupedRows.args = {
   } as TableProps['tableSettings'],
   groupedRows: {
     enabled: true,
-    groupBy: 'platform'
+    groupBy: 'genre'
   } as TableProps['groupedRows'],
   noDataMessage: 'No data found',
   // story props
   storyTitle: 'Table with Grouped Rows (Excel-style merged cells)',
-  storyDescription: 'Platform values are merged in Excel-style with rowspan, showing each platform name only once per group. Each platform (TMPOC, TMPOC Lite, FLEX DDC, FLEX APR) should show US, JP, and Actual Global as regions underneath.'
+  storyDescription: 'Genre values are merged in Excel-style with rowspan, showing each genre name only once per group. Each genre (Fiction, Non-Fiction, Science, Biography) shows multiple books underneath with their titles, authors, page counts, and ratings.'
 };
 

--- a/src/stories/Table/Table.stories.tsx
+++ b/src/stories/Table/Table.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryFn } from '@storybook/react-webpack5';
 import Button from 'src/components/Button/Button';
 import TableComponent, { TableProps } from 'src/components/Table';
 import DocBlock from '.storybook/DocBlock';
-import { CUSTOM_DATA, EXPORT_DATA, FAULTY_DATA, INFINITE_SCROLL_DATA, INITIAL_SORT_BY_DATA } from './tableStoryData';
+import { CUSTOM_DATA, EXPORT_DATA, FAULTY_DATA, GROUPED_ROWS_DATA, INFINITE_SCROLL_DATA, INITIAL_SORT_BY_DATA } from './tableStoryData';
 import {
   COLUMNS,
   COLUMNS_WITH_WIDTH,
@@ -11,6 +11,7 @@ import {
   COLUMNS_WITH_RESIZING,
   FAULTY_COLUMNS,
   EXPORT_COLUMNS,
+  GROUPED_ROWS_COLUMNS,
   renderRowSubComponent,
 } from './tableStoryUtil';
 import { StyledTableComponent } from './tableStoryStyles';
@@ -333,5 +334,39 @@ TableWithResizableColumns.args = {
   // story props
   storyTitle: 'Table with Resizable Columns',
   storyDescription: 'Drag the edges of the column headers to resize columns. Resize handles are visible on hover or when a column is actively being resized. In this example, all columns except the last one can be resized.'
+};
+
+const GroupedRowsTemplate: StoryFn<TableProps & StoryInfo> = (args) => {
+  return (
+    <>
+      <div style={{ marginTop: 10, marginLeft: 10 }}>
+        <h2>{args.storyTitle || ''}</h2>
+        <p>{args.storyDescription || ''}</p>
+      </div>
+      <TableComponent {...args} />
+    </>
+  );
+};
+
+export const TableWithGroupedRows = GroupedRowsTemplate.bind({});
+TableWithGroupedRows.args = {
+
+  columns: GROUPED_ROWS_COLUMNS,
+  data: GROUPED_ROWS_DATA,
+  tableSettings: {
+    columnConfig: {
+      enableColumnHiding: true
+    },
+    enableDownload: true,
+    downloadFilename: 'my-table-export.csv'
+  } as TableProps['tableSettings'],
+  groupedRows: {
+    enabled: true,
+    groupBy: 'platform'
+  } as TableProps['groupedRows'],
+  noDataMessage: 'No data found',
+  // story props
+  storyTitle: 'Table with Grouped Rows (Excel-style merged cells)',
+  storyDescription: 'Platform values are merged in Excel-style with rowspan, showing each platform name only once per group. Each platform (TMPOC, TMPOC Lite, FLEX DDC, FLEX APR) should show US, JP, and Actual Global as regions underneath.'
 };
 

--- a/src/stories/Table/tableStoryData.ts
+++ b/src/stories/Table/tableStoryData.ts
@@ -53,16 +53,16 @@ export const INFINITE_SCROLL_DATA = [
 ];
 
 export const GROUPED_ROWS_DATA = [
-  { platform: 'TMPOC', region: 'US', total: 7, online: 0, offline: 7 },
-  { platform: 'TMPOC', region: 'JP', total: 3, online: 0, offline: 3 },
-  { platform: 'TMPOC', region: 'Actual Global', total: 10, online: 0, offline: 10 },
-  { platform: 'TMPOC Lite', region: 'US', total: 7, online: 0, offline: 7 },
-  { platform: 'TMPOC Lite', region: 'JP', total: 3, online: 0, offline: 3 },
-  { platform: 'TMPOC Lite', region: 'Actual Global', total: 10, online: 0, offline: 10 },
-  { platform: 'FLEX DDC', region: 'US', total: 7, online: 0, offline: 7 },
-  { platform: 'FLEX DDC', region: 'JP', total: 3, online: 0, offline: 3 },
-  { platform: 'FLEX DDC', region: 'Actual Global', total: 10, online: 0, offline: 10 },
-  { platform: 'FLEX APR', region: 'US', total: 7, online: 0, offline: 7 },
-  { platform: 'FLEX APR', region: 'JP', total: 3, online: 0, offline: 3 },
-  { platform: 'FLEX APR', region: 'Actual Global', total: 10, online: 0, offline: 10 }
+  { genre: 'Fiction', title: 'The Great Adventure', author: 'Jane Smith', pages: 324, rating: 4.2 },
+  { genre: 'Fiction', title: 'Mystery of the Lake', author: 'John Doe', pages: 278, rating: 4.5 },
+  { genre: 'Fiction', title: 'Summer Romance', author: 'Alice Johnson', pages: 245, rating: 3.8 },
+  { genre: 'Non-Fiction', title: 'History of Technology', author: 'Dr. Brown', pages: 456, rating: 4.1 },
+  { genre: 'Non-Fiction', title: 'Cooking Mastery', author: 'Chef Maria', pages: 312, rating: 4.7 },
+  { genre: 'Non-Fiction', title: 'Travel Guide Europe', author: 'Sam Wilson', pages: 198, rating: 4.3 },
+  { genre: 'Science', title: 'Quantum Physics Simplified', author: 'Prof. Lee', pages: 387, rating: 4.0 },
+  { genre: 'Science', title: 'Biology Basics', author: 'Dr. Chen', pages: 298, rating: 4.4 },
+  { genre: 'Science', title: 'Chemistry Lab Guide', author: 'Prof. Davis', pages: 156, rating: 3.9 },
+  { genre: 'Biography', title: 'Life of a Pioneer', author: 'Robert Taylor', pages: 234, rating: 4.6 },
+  { genre: 'Biography', title: 'Artist Journey', author: 'Emily White', pages: 289, rating: 4.2 },
+  { genre: 'Biography', title: 'Sports Legend', author: 'Mike Green', pages: 267, rating: 4.1 }
 ];

--- a/src/stories/Table/tableStoryData.ts
+++ b/src/stories/Table/tableStoryData.ts
@@ -51,3 +51,18 @@ export const INFINITE_SCROLL_DATA = [
     total: parseFloat((Math.random()).toFixed(8))
   }))
 ];
+
+export const GROUPED_ROWS_DATA = [
+  { platform: 'TMPOC', region: 'US', total: 7, online: 0, offline: 7 },
+  { platform: 'TMPOC', region: 'JP', total: 3, online: 0, offline: 3 },
+  { platform: 'TMPOC', region: 'Actual Global', total: 10, online: 0, offline: 10 },
+  { platform: 'TMPOC Lite', region: 'US', total: 7, online: 0, offline: 7 },
+  { platform: 'TMPOC Lite', region: 'JP', total: 3, online: 0, offline: 3 },
+  { platform: 'TMPOC Lite', region: 'Actual Global', total: 10, online: 0, offline: 10 },
+  { platform: 'FLEX DDC', region: 'US', total: 7, online: 0, offline: 7 },
+  { platform: 'FLEX DDC', region: 'JP', total: 3, online: 0, offline: 3 },
+  { platform: 'FLEX DDC', region: 'Actual Global', total: 10, online: 0, offline: 10 },
+  { platform: 'FLEX APR', region: 'US', total: 7, online: 0, offline: 7 },
+  { platform: 'FLEX APR', region: 'JP', total: 3, online: 0, offline: 3 },
+  { platform: 'FLEX APR', region: 'Actual Global', total: 10, online: 0, offline: 10 }
+];

--- a/src/stories/Table/tableStoryUtil.tsx
+++ b/src/stories/Table/tableStoryUtil.tsx
@@ -167,29 +167,29 @@ export const COLUMNS_WITH_WIDTH_AND_EXPANDER = [
 
 export const GROUPED_ROWS_COLUMNS = [
   {
-    header: 'Platform',
-    accessorKey: 'platform',
+    header: 'Genre',
+    accessorKey: 'genre',
     cell: ({ getValue }) => getValue()
   },
   {
-    header: 'Region',
-    accessorKey: 'region',
+    header: 'Title',
+    accessorKey: 'title',
     cell: ({ getValue }) => getValue()
   },
   {
-    header: 'Total',
-    accessorKey: 'total',
+    header: 'Author',
+    accessorKey: 'author',
     cell: ({ getValue }) => getValue()
   },
   {
-    header: 'Online',
-    accessorKey: 'online',
+    header: 'Pages',
+    accessorKey: 'pages',
     cell: ({ getValue }) => getValue()
   },
   {
-    header: 'Offline',
-    accessorKey: 'offline',
-    cell: ({ getValue }) => getValue()
+    header: 'Rating',
+    accessorKey: 'rating',
+    cell: ({ getValue }) => `⭐ ${getValue()}`
   }
 ];
 

--- a/src/stories/Table/tableStoryUtil.tsx
+++ b/src/stories/Table/tableStoryUtil.tsx
@@ -165,6 +165,34 @@ export const COLUMNS_WITH_WIDTH_AND_EXPANDER = [
   }
 ];
 
+export const GROUPED_ROWS_COLUMNS = [
+  {
+    header: 'Platform',
+    accessorKey: 'platform',
+    cell: ({ getValue }) => getValue()
+  },
+  {
+    header: 'Region',
+    accessorKey: 'region',
+    cell: ({ getValue }) => getValue()
+  },
+  {
+    header: 'Total',
+    accessorKey: 'total',
+    cell: ({ getValue }) => getValue()
+  },
+  {
+    header: 'Online',
+    accessorKey: 'online',
+    cell: ({ getValue }) => getValue()
+  },
+  {
+    header: 'Offline',
+    accessorKey: 'offline',
+    cell: ({ getValue }) => getValue()
+  }
+];
+
 export const renderRowSubComponent = ({ row }) => {
   const { value, percentage, percentage_change, total } = row.original;
   const nestedData = [

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -47,6 +47,10 @@ const THEME: Theme = {
         primary: colors.white,
         secondary: colors.akoya,
         tertiary: colors.akoya,
+        table: {
+            groupedRowPrimary: colors.white,
+            groupedRowSecondary: colors.selago,
+        },
         widget: {
           primary: colors.gunpowder,
           dark: colors.storm,
@@ -144,6 +148,10 @@ export const DARK_THEME: Theme = {
         primary: colors.gunpowder,
         secondary: colors.storm,
         tertiary: colors.dolphin,
+        table: {
+            groupedRowPrimary: colors.gunpowder,
+            groupedRowSecondary: colors.dolphin,
+        },
         widget: {
           primary: colors.white,
           dark: colors.storm,

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -79,6 +79,10 @@ export interface LakefrontTheme {
         primary: string;
         secondary: string;
         tertiary: string;
+        table: {
+            groupedRowPrimary: string;
+            groupedRowSecondary: string;
+        };
         widget: WidgetStyles;
         disabled: string;
         inverted: string;


### PR DESCRIPTION
### Lakefront PR Checklist

- [ ]  Created new components following the [contributing guide](#https://github.com/woven-by-toyota/lakefront/blob/main/CONTRIBUTING.md#adding-new-components).
- [ ]  Exported any new components in the `src/index.ts`.
- [ ]  Updated the main [README table](https://github.com/woven-by-toyota/lakefront#how-to-add-components-to-this-table).
- [X]  Ensure version numbers were bumped properly.
- [ ]  Imported SVGs with relative path, if applicable.
- [ ]  Removed any irrelevant commit messages from merge commit.

## Overview                                                                                                               
  This PR adds grouped rows functionality to the Table component, providing Excel-style merged cells for visually grouping  
  rows by a specified column. When enabled, rows with the same value in the grouped column will display that value only     
  once, spanning multiple rows with `rowSpan`.
                                                                                                                            
  ## Features Added                                                                                                         
   
  ### 🆕 GroupedRowsConfig Interface                                                                                        
  - `enabled: boolean` - Enable/disable grouped rows functionality
  - `groupBy: string` - Column ID to group by (e.g., 'platform')                                                            
                                                                                                                            
  ### 🎨 Visual Grouping                                                                                                    
  - **Excel-style merged cells** - Grouped column values appear once and span multiple rows                                 
  - **Custom styling** - Grouped cells have distinct background color, centered text, and bold font weight                  
  - **Theme-aware** - Uses theme colors that adapt to light/dark modes                                                      
                                                                                                                            
  ### 🔧 Technical Implementation                                                                                           
  - **New `GroupedCell` styled component** - Themed component for grouped cells with proper specificity                     
  - **Enhanced TableRow logic** - Handles rowspan calculation and cell rendering logic                                      
  - **Smart row indexing** - Reliable row positioning with fallback mechanisms                                              
  - **Null cell filtering** - Efficiently filters out non-rendered cells                                                    
                                                                                                                            
  ### 🚫 Sorting Restrictions                                                                                               
  - **Conditional sorting** - When grouping is enabled, only the grouped column remains sortable                            
  - **Prevents breaking** - Sorting by other columns would break the visual grouping                                        
  - **Maintains grouping** - Ensures grouped appearance is preserved  


With Alternate Colors
<img width="2700" height="901" alt="image" src="https://github.com/user-attachments/assets/4dfa5a18-6552-43ad-bdf5-7c77cd83badd" />
<img width="2700" height="878" alt="image" src="https://github.com/user-attachments/assets/3e007890-f87b-4860-a632-d51ed2ce5fc6" />


Without Alternate Colors
<img width="2700" height="901" alt="image" src="https://github.com/user-attachments/assets/e250d8ed-e159-4a28-a219-c4d45a234ed0" />
<img width="2700" height="878" alt="image" src="https://github.com/user-attachments/assets/5eb1cc6b-f423-4748-93e8-f6b58f09b05d" />


                          
