### PR TITLE
Fix MultiSelectFilter reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "9.5.1",
+  "version": "9.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "9.5.1",
+      "version": "9.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "9.5.2",
+  "version": "9.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "9.5.2",
+      "version": "9.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "9.5.2",
+  "version": "9.6.0",
   "type": "module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "9.5.1",
+  "version": "9.5.2",
   "type": "module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/components/Filter/modules/MultiSelectFilter/MultiSelectFilter.tsx
+++ b/src/components/Filter/modules/MultiSelectFilter/MultiSelectFilter.tsx
@@ -51,16 +51,20 @@ const MultiSelectFilter = (
     getDefaultFilterValue: () => initialValue !== INITIAL_VALUE ? initialValue : [],
     clearPartialSingleFilter: (originalValue, value) => originalValue.filter((original) => original !== value),
     isDefaultFilterValue: (value) => {
+        // No custom initialValue provided - default is empty array or all options selected
         if (value && initialValue === INITIAL_VALUE) {
             if (value.length === 0) {
                 return true;
             }
             return value.length === options.length;
         }
+
+        // Custom initialValue provided - match against that value
         if (value && initialValue !== INITIAL_VALUE) {
             return value.length === initialValue.length &&
                    value.every((v: string) => initialValue.includes(v));
         }
+
         return false;
     },
     getFilterBarLabel: (values) => {

--- a/src/components/Filter/modules/MultiSelectFilter/MultiSelectFilter.tsx
+++ b/src/components/Filter/modules/MultiSelectFilter/MultiSelectFilter.tsx
@@ -8,16 +8,16 @@ const INITIAL_VALUE: [] = [];
  * MultiSelectFilter Component
  * 
  * The MultiSelectFilter component is a multi select dropdown filter. While the default
- * behaviour should suffice, any valid `FilterModule` property (excluding description and label) can
+ * behavior should suffice, any valid `FilterModule` property (excluding description and label) can
  * be supplied via the `multiSelectFilterOptions` parameter to change how the filter looks and acts.
  * MultiSelectFilter arguments include:
  *
  * `multiSelectFilterProps` - The props required to be supplied as the first argument of
  * the MultiSelectFilter component. If the *optional* `delimiter` prop is provided, input parsing
- * will be enabled to allow typing/pasting multiple values seperated by the chosen delimiter.
+ * will be enabled to allow typing/pasting multiple values separated by the chosen delimiter.
  *
  * `multiSelectFilterOptions` - Any valid `FilterModule` property (excluding description and label)
- * meant to override default text filter behaviour.
+ * meant to override default text filter behavior.
  */
 const MultiSelectFilter = (
     {
@@ -48,14 +48,18 @@ const MultiSelectFilter = (
         }
     },
     getBrowserQueryUrlValue: (value) => value,
-    getDefaultFilterValue: () => [],
+    getDefaultFilterValue: () => initialValue !== INITIAL_VALUE ? initialValue : [],
     clearPartialSingleFilter: (originalValue, value) => originalValue.filter((original) => original !== value),
     isDefaultFilterValue: (value) => {
-        if (value) {
+        if (value && initialValue === INITIAL_VALUE) {
             if (value.length === 0) {
                 return true;
             }
             return value.length === options.length;
+        }
+        if (value && initialValue !== INITIAL_VALUE) {
+            return value.length === initialValue.length &&
+                   value.every((v: string) => initialValue.includes(v));
         }
         return false;
     },


### PR DESCRIPTION
This PR fixes an issue where resetting a `MultiSelectFilter` that had `initialValues` would not re-initialize (but instead clear all values).

<img width="1118" height="532" alt="fixedMultiselect" src="https://github.com/user-attachments/assets/e54b476b-fe09-42f5-8710-503975120625" />


### Lakefront PR Checklist
- [ ]  Ensure version numbers were bumped properly.
- [ ]  Removed any irrelevant commit messages from merge commit.
