### PR TITLE
TextFilter whitespace fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "10.0.1",
+      "version": "10.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/helpers": "^0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "10.0.0",
+      "version": "10.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/helpers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "type": "module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "type": "module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/components/Filter/modules/TextFilter/TextFilter.tsx
+++ b/src/components/Filter/modules/TextFilter/TextFilter.tsx
@@ -3,6 +3,7 @@ import { FilterModule, TextFilterOverrides } from 'src/components/Filter/types';
 
 export interface TextFilterOptions {
     type?: 'text' | 'number';
+    trimWhitespace?: boolean;
 }
 
 /**
@@ -19,34 +20,55 @@ export interface TextFilterOptions {
  * `textFilterOverrides` - Any valid `FilterModule` property (excluding description and label)
  * which will override default text filter behaviour.
  * 
- * `textFilterOptions` - Used to set additional textFilter options such as the type of text input.
+ * `textFilterOptions` - Used to set additional textFilter options such as the type of text input and whether
+ * leading/trailing whitespace is trimmed (`trimWhitespace`, which defaults to `true`).
  */
 const TextFilter = (
     label: string,
     description?: string,
     textFilterOverrides: TextFilterOverrides = {},
     textFilterOptions: TextFilterOptions = {}
-): FilterModule<string> => ({
-    getApiQueryUrl: (key, value) => {
-        return value ? `&${key}=${encodeURIComponent(value)}` : '';
-    },
-    getApiPostBody: (key, value) => (value ? { [key]: value } : undefined),
-    getBrowserQueryUrlValue: (value) => value,
-    getDefaultFilterValue: () => '',
-    isDefaultFilterValue: (value) => value === '',
-    getFilterBarLabel: (value) => value,
-    getFilterSectionLabel: (value) => value,
-    parseInitialFilterValue: (browserQueryUrlValue: string) => browserQueryUrlValue || '',
-    renderComponent: ({ name, value, update }) => (
-        <TextSearch key={name} onChange={update} value={value} type={textFilterOptions.type} />
-    ),
-    getFilterCount(value?: string): number {
-        return value ? 1 : 0;
-    },
-    ...textFilterOverrides,
-    description,
-    label
-});
+): FilterModule<string> => {
+    const { trimWhitespace = true } = textFilterOptions;
+
+    // Leading/trailing whitespace is rarely intended as part of a search term and often causes
+    // requests to return no results, so it is removed unless the consumer opts out.
+    const trim = (value?: string) => (trimWhitespace && typeof value === 'string' ? value.trim() : value);
+
+    return {
+        getApiQueryUrl: (key, value) => {
+            const trimmedValue = trim(value);
+
+            return trimmedValue ? `&${key}=${encodeURIComponent(trimmedValue)}` : '';
+        },
+        getApiPostBody: (key, value) => {
+            const trimmedValue = trim(value);
+
+            return trimmedValue ? { [key]: trimmedValue } : undefined;
+        },
+        getBrowserQueryUrlValue: (value) => trim(value),
+        getDefaultFilterValue: () => '',
+        isDefaultFilterValue: (value) => trim(value) === '',
+        getFilterBarLabel: (value) => value,
+        getFilterSectionLabel: (value) => value,
+        parseInitialFilterValue: (browserQueryUrlValue: string) => trim(browserQueryUrlValue) || '',
+        renderComponent: ({ name, value, update }) => (
+            <TextSearch
+                key={name}
+                onChange={update}
+                value={value}
+                type={textFilterOptions.type}
+                trimWhitespace={trimWhitespace}
+            />
+        ),
+        getFilterCount(value?: string): number {
+            return trim(value) ? 1 : 0;
+        },
+        ...textFilterOverrides,
+        description,
+        label
+    };
+};
 
 export default TextFilter;
 

--- a/src/components/Filter/modules/TextFilter/TextSearch.tsx
+++ b/src/components/Filter/modules/TextFilter/TextSearch.tsx
@@ -5,9 +5,10 @@ interface TextSearchProps {
     onChange(text: string): void;
     type?: 'text' | 'number';
     value: string;
+    trimWhitespace?: boolean;
 }
 
-const TextSearch: FC<TextSearchProps> = ({ onChange, type = 'text', value }) => {
+const TextSearch: FC<TextSearchProps> = ({ onChange, type = 'text', value, trimWhitespace = true }) => {
     const [text, setText] = useState('');
 
     useEffect(() => {
@@ -15,7 +16,11 @@ const TextSearch: FC<TextSearchProps> = ({ onChange, type = 'text', value }) => 
     }, [value]);
 
     const submitSearch = (text: string) => {
-        onChange(text);
+        // Whitespace is trimmed on submit (rather than on change) so that it can still be typed between words.
+        const submittedText = trimWhitespace ? text.trim() : text;
+
+        setText(submittedText);
+        onChange(submittedText);
     };
 
     const handleOnBlur = (event: FocusEvent<HTMLInputElement>) => {

--- a/src/components/Filter/modules/TextFilter/__tests__/textFilter.test.js
+++ b/src/components/Filter/modules/TextFilter/__tests__/textFilter.test.js
@@ -188,6 +188,50 @@ describe('TextFilter', () => {
         });
     });
 
+    describe('trimWhitespace', () => {
+        it('trims leading and trailing whitespace by default', () => {
+            const {
+                getApiQueryUrl,
+                getApiPostBody,
+                getBrowserQueryUrlValue,
+                isDefaultFilterValue,
+                parseInitialFilterValue,
+                getFilterCount
+            } = TextFilter('', '');
+
+            expect(getApiQueryUrl('a', '  first name  ')).toBe('&a=first%20name');
+            expect(getApiPostBody('a', '  first name  ')).toMatchObject({ a: 'first name' });
+            expect(getBrowserQueryUrlValue('  a  ')).toBe('a');
+            expect(parseInitialFilterValue('  a  ')).toBe('a');
+
+            // whitespace-only values are treated the same as no value at all
+            expect(getApiQueryUrl('a', '   ')).toBe('');
+            expect(getApiPostBody('a', '   ')).toBeUndefined();
+            expect(isDefaultFilterValue('   ')).toBe(true);
+            expect(getFilterCount('   ')).toBe(0);
+        });
+
+        it('keeps whitespace when trimWhitespace is false', () => {
+            const { getApiQueryUrl, getApiPostBody, isDefaultFilterValue, getFilterCount } = TextFilter('', '', {}, {
+                trimWhitespace: false
+            });
+
+            expect(getApiQueryUrl('a', '  a  ')).toBe('&a=%20%20a%20%20');
+            expect(getApiPostBody('a', '  a  ')).toMatchObject({ a: '  a  ' });
+            expect(isDefaultFilterValue('   ')).toBe(false);
+            expect(getFilterCount('   ')).toBe(1);
+        });
+
+        it('renders an input that trims whitespace on submit', () => {
+            const { renderComponent } = TextFilter('', '');
+
+            const update = jest.fn();
+            const { getByRole } = render(<div>{renderComponent({ name: 'name', value: '1', update })}</div>);
+            fireEvent.blur(getByRole('textbox'), { target: { value: '  asdf  ' } });
+            expect(update).toHaveBeenCalledWith('asdf');
+        });
+    });
+
     describe('getFilterCount', () => {
         const { getFilterCount } = TextFilter('', '');
 

--- a/src/components/Filter/modules/TextFilter/__tests__/textSearch.test.js
+++ b/src/components/Filter/modules/TextFilter/__tests__/textSearch.test.js
@@ -31,6 +31,28 @@ describe('<TextSearch />', () => {
         expect(changeCallback).toHaveBeenCalledWith('asdf');
     });
 
+    it('trims leading and trailing whitespace on submit', () => {
+        const changeCallback = jest.fn();
+        const { getByRole } = render(<TextSearch onChange={changeCallback} />);
+        fireEvent.blur(getByRole('textbox'), { target: { value: '  asdf  ' } });
+        expect(changeCallback).toHaveBeenCalledWith('asdf');
+        expect(getByRole('textbox')).toHaveValue('asdf');
+    });
+
+    it('does not trim whitespace between words', () => {
+        const changeCallback = jest.fn();
+        const { getByRole } = render(<TextSearch onChange={changeCallback} />);
+        fireEvent.blur(getByRole('textbox'), { target: { value: ' first  last ' } });
+        expect(changeCallback).toHaveBeenCalledWith('first  last');
+    });
+
+    it('keeps whitespace when trimWhitespace is false', () => {
+        const changeCallback = jest.fn();
+        const { getByRole } = render(<TextSearch onChange={changeCallback} trimWhitespace={false} />);
+        fireEvent.blur(getByRole('textbox'), { target: { value: '  asdf  ' } });
+        expect(changeCallback).toHaveBeenCalledWith('  asdf  ');
+    });
+
     it('only accepts numbers when specified', () => {
         const changeCallback = jest.fn();
         const { getByRole } = render(<TextSearch onChange={changeCallback} type='number' />);

--- a/src/components/Filter/modules/TextFilter/__tests__/textSearch.test.js
+++ b/src/components/Filter/modules/TextFilter/__tests__/textSearch.test.js
@@ -1,7 +1,19 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithTheme as render } from 'src/lib/testing';
 import TextSearch from '../TextSearch';
+
+/**
+ * Mimic user type/submit event
+ */
+const typeAndSubmit = async (input, text) => {
+    const user = userEvent.setup();
+
+    await user.type(input, text);
+    // tabbing away blurs the input, which is what submits the search
+    await user.tab();
+};
 
 describe('<TextSearch />', () => {
     it('renders input text', () => {
@@ -31,26 +43,48 @@ describe('<TextSearch />', () => {
         expect(changeCallback).toHaveBeenCalledWith('asdf');
     });
 
-    it('trims leading and trailing whitespace on submit', () => {
+    it('trims leading and trailing whitespace on submit', async () => {
         const changeCallback = jest.fn();
-        const { getByRole } = render(<TextSearch onChange={changeCallback} />);
-        fireEvent.blur(getByRole('textbox'), { target: { value: '  asdf  ' } });
+        const { getByRole } = render(<TextSearch onChange={changeCallback} value='' />);
+        const input = getByRole('textbox');
+
+        await typeAndSubmit(input, '  asdf  ');
+
         expect(changeCallback).toHaveBeenCalledWith('asdf');
-        expect(getByRole('textbox')).toHaveValue('asdf');
+        expect(input).toHaveValue('asdf');
     });
 
-    it('does not trim whitespace between words', () => {
+    it('clears the input when only whitespace is submitted', async () => {
         const changeCallback = jest.fn();
-        const { getByRole } = render(<TextSearch onChange={changeCallback} />);
-        fireEvent.blur(getByRole('textbox'), { target: { value: ' first  last ' } });
+        const { getByRole } = render(<TextSearch onChange={changeCallback} value='' />);
+        const input = getByRole('textbox');
+
+        await typeAndSubmit(input, '   ');
+
+        expect(changeCallback).toHaveBeenCalledWith('');
+        expect(input).toHaveValue('');
+    });
+
+    it('does not trim whitespace between words', async () => {
+        const changeCallback = jest.fn();
+        const { getByRole } = render(<TextSearch onChange={changeCallback} value='' />);
+        const input = getByRole('textbox');
+
+        await typeAndSubmit(input, ' first  last ');
+
         expect(changeCallback).toHaveBeenCalledWith('first  last');
+        expect(input).toHaveValue('first  last');
     });
 
-    it('keeps whitespace when trimWhitespace is false', () => {
+    it('keeps whitespace when trimWhitespace is false', async () => {
         const changeCallback = jest.fn();
-        const { getByRole } = render(<TextSearch onChange={changeCallback} trimWhitespace={false} />);
-        fireEvent.blur(getByRole('textbox'), { target: { value: '  asdf  ' } });
+        const { getByRole } = render(<TextSearch onChange={changeCallback} value='' trimWhitespace={false} />);
+        const input = getByRole('textbox');
+
+        await typeAndSubmit(input, '  asdf  ');
+
         expect(changeCallback).toHaveBeenCalledWith('  asdf  ');
+        expect(input).toHaveValue('  asdf  ');
     });
 
     it('only accepts numbers when specified', () => {

--- a/src/stories/Filter/TextFilter/TextFilterDocs.tsx
+++ b/src/stories/Filter/TextFilter/TextFilterDocs.tsx
@@ -35,7 +35,8 @@ export interface TextFilterArgs {
             ...additionalTextFilterOverrides
         },
         {
-            type: 'text'
+            type: 'text',
+            trimWhitespace: true
         },
     )
 }`);
@@ -44,8 +45,11 @@ export interface TextFilterArgs {
  * TextFilter Component
  * 
  * The TextFilter component is a text input control meant to be used as a keyword(s) search. While the default
- * behaviour should suffice, any valid `FilterModule` property (excluding description and label) can
+ * behavior should suffice, any valid `FilterModule` property (excluding description and label) can
  * be supplied via the `textFilterOverrides` parameter to change how the filter looks and acts.
+ *
+ * Leading/trailing whitespace is trimmed when the search is submitted. Set the `trimWhitespace` text filter
+ * option to `false` to keep it.
  */
 const TextFilterDocs: FC<TextFilterArgs> = () => null;
 


### PR DESCRIPTION
## Summary

`TextFilter` now trims leading and trailing whitespace from search values by default, so padded input no longer produces requests that return no results. A new `trimWhitespace` text filter option (default `true`) is available for filters that need whitespace preserved.

## Changes

- Trim whitespace when a `TextSearch` value is submitted (blur or Enter) and reflect the trimmed value back in the input. Whitespace between words is preserved.
- Trim values in `getApiQueryUrl`, `getApiPostBody`, `getBrowserQueryUrlValue`, and `parseInitialFilterValue`, so values sourced from the browser url, the JSON editor, or preset values are trimmed as well.
- Treat whitespace-only values as unset: `isDefaultFilterValue` returns `true` and `getFilterCount` returns `0`, so no filter bar chip or query param is applied.
- Add the `trimWhitespace` option to `TextFilterOptions` (defaults to `true`) so consumers can opt out and keep whitespace as typed.
- Add `TextFilter` and `TextSearch` tests covering trimming, whitespace between words, whitespace-only values, and the opt-out.
- Document the new option in the TextFilter storybook docs.
---
*Generated by Claude*

<img width="1048" height="560" alt="whitespaceTrim" src="https://github.com/user-attachments/assets/44150133-832a-46ae-91a9-1e001b9b1cfa" />

### Lakefront PR Checklist
- [ ]  Ensure version numbers were bumped properly.
- [ ]  Removed any irrelevant commit messages from merge commit.
